### PR TITLE
chore: make frames public

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dart.flutterSdkPath": "/Users/oscarmartin/fvm/default"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "dart.flutterSdkPath": "/Users/oscarmartin/fvm/default"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.2.1]
+
+* `Exporter` class exposes now `frames`.
+
 ## [0.2.0]
 
 * `Exporter` class exposes now `exportGif` and `exportFrames`.

--- a/lib/src/exporter.dart
+++ b/lib/src/exporter.dart
@@ -7,6 +7,8 @@ import 'package:screen_recorder/src/frame.dart';
 
 class Exporter {
   final List<Frame> _frames = [];
+  List<Frame> get frames => _frames;
+
   void onNewFrame(Frame frame) {
     _frames.add(frame);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: screen_recorder
 description: Record your Flutter widgets and export the recordings as a GIF
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/ueman/screenrecorder
 issue_tracker: https://github.com/ueman/screenrecorder/issues
 funding:


### PR DESCRIPTION
In order to manipulate the frames wihout modifying the exporter we need to get access to those.